### PR TITLE
Remove @BodySize

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <webapp.directory>src/main/webapp</webapp.directory>
 
         <!-- Dependencies -->
-        <vaadin.version>10.0.0.beta5</vaadin.version>
+        <vaadin.version>10.0.0.beta6</vaadin.version>
         <spring-boot.version>2.0.0.RELEASE</spring-boot.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <webapp.directory>src/main/webapp</webapp.directory>
 
         <!-- Dependencies -->
-        <vaadin.version>10.0.0.beta6</vaadin.version>
+        <vaadin.version>10.0.0.beta7</vaadin.version>
         <spring-boot.version>2.0.0.RELEASE</spring-boot.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
                     <plugin>
                         <groupId>com.vaadin</groupId>
                         <artifactId>flow-maven-plugin</artifactId>
-                        <version>1.0.0.beta2</version>
+                        <version>1.0.0.beta6</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/src/main/java/com/vaadin/starter/skeleton/spring/MainView.java
+++ b/src/main/java/com/vaadin/starter/skeleton/spring/MainView.java
@@ -3,7 +3,6 @@ package com.vaadin.starter.skeleton.spring;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.component.page.BodySize;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.lumo.Lumo;

--- a/src/main/java/com/vaadin/starter/skeleton/spring/MainView.java
+++ b/src/main/java/com/vaadin/starter/skeleton/spring/MainView.java
@@ -15,7 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 @HtmlImport("styles/shared-styles.html")
 @Route("")
 @Theme(Lumo.class)
-@BodySize(height = "100vh", width = "100vw")
 public class MainView extends VerticalLayout {
 
     public MainView(@Autowired ExampleTemplate template) {


### PR DESCRIPTION
DON'T MERGE until this project is depending on Flow version where vaadin/flow#3821 is included. After that the full body size is applied by default and the annotation is not needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-spring/62)
<!-- Reviewable:end -->
