### PR TITLE
Removed obsolete dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,14 +19,10 @@
 
         <!-- Dependencies -->
         <vaadin.version>10.0.0.rc1</vaadin.version>
-        <spring-boot.version>2.0.0.RELEASE</spring-boot.version>
+        <spring-boot.version>2.0.2.RELEASE</spring-boot.version>
     </properties>
 
     <pluginRepositories>
-        <pluginRepository>
-            <id>spring-milestone</id>
-            <url>https://repo.spring.io/milestone/</url>
-        </pluginRepository>
         <pluginRepository>
             <id>vaadin-prereleases</id>
             <url>https://maven.vaadin.com/vaadin-prereleases</url>
@@ -42,10 +38,6 @@
              <id>Vaadin Directory</id>
              <url>http://maven.vaadin.com/vaadin-addons</url>
         </repository>        
-        <repository>
-            <id>spring-milestone</id>
-            <url>https://repo.spring.io/milestone/</url>
-        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -70,11 +70,6 @@
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spring-boot-starter</artifactId>
             <version>${vaadin.version}</version>
         </dependency>


### PR DESCRIPTION
Comes via vaadin-spring-boot-starter, like vaadin-spring should too (but it currently don't)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-spring/73)
<!-- Reviewable:end -->
