### PR TITLE
Update vaadin version back to 12.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Dependencies -->
-        <vaadin.version>12.0.1</vaadin.version>
+        <vaadin.version>12.0.0</vaadin.version>
     </properties>
 
     <parent>


### PR DESCRIPTION
Because of a known bug in `vaadin-context-menu-flow 1.2.1` which is part of `vaadin 12.0.1`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-spring/111)
<!-- Reviewable:end -->
