### PR TITLE
Remove gson stub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,13 +121,6 @@
             <artifactId>flow-html-components</artifactId>
             <version>2.0-SNAPSHOT</version>
         </dependency>
-
-        <!-- TODO remove it and fix the actual problem in https://github.com/vaadin/flow/issues/5426 -->
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.7</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
The gson stub is not needed anymore after the snapshot with https://github.com/vaadin/flow/pull/5460 change is released

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-spring/138)
<!-- Reviewable:end -->
