### PR TITLE
Ensure app is run in npm mode

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,8 @@
 server.port=8080
 # This is a workaround for https://github.com/vaadin/spring/issues/381
 spring.servlet.multipart.enabled = false
+# Ensure application is run in Vaadin 14/npm mode
+vaadin.compatibilityMode = false
+
 
 logging.level.org.atmosphere = warn


### PR DESCRIPTION
Depends on https://github.com/vaadin/spring/pull/453 for Spring to read the property and on https://github.com/vaadin/flow/pull/5944 to give a sensible error message

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-spring/173)
<!-- Reviewable:end -->
