### PR TITLE
Exclude webjars from boot starter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,10 +86,6 @@
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-spring-boot-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <!-- Replace artifactId with vaadin-core to use only free components -->
             <artifactId>vaadin</artifactId>
             <exclusions>
@@ -118,6 +114,15 @@
                     <groupId>org.webjars.bowergithub.webcomponents</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-spring-boot-starter</artifactId>
+            <exclusions>
+                <!-- Excluding so that webjars are not included. -->
+                <exclusion><groupId>com.vaadin</groupId>
+                    <artifactId>vaadin-core</artifactId></exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Not enough to exclude from vaadin dependency. Excluding vaadin-core is
cleaner than excluding the webjars here, as it is not needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-spring/181)
<!-- Reviewable:end -->
