### PR TITLE
CCDM: Add client-side bootstrap and routing facilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
 branches:
   only:
     - master
+    - ccdm
 cache:
   directories:
   - $HOME/.m2

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Project Base for Vaadin Flow with Spring</title>
+  <!-- index.ts is included here automatically (either by the dev server or during the build) -->
+</head>
+<body>
+  <script src="VAADIN/build/webcomponentsjs/webcomponents-loader.js"></script>
+  <div id="outlet"></div>
+</body>
+</html>

--- a/frontend/index.ts
+++ b/frontend/index.ts
@@ -1,0 +1,22 @@
+import {Flow} from '@vaadin/flow-frontend/Flow';
+import {Router} from '@vaadin/router';
+
+const flow = new Flow({
+  // @ts-ignore
+  imports: () => import('../target/frontend/generated-flow-imports')
+});
+
+const routes = [
+  {
+    // fallback to server-side Flow routes if no client-side routes match
+    path: '(.*)',
+
+    // FIXME: replace flow.navigate with flow.route()
+    // when https://github.com/vaadin/flow/issues/6338 is implemented
+    action: flow.navigate as any
+  }
+];
+
+const router = new Router(document.querySelector('#outlet'));
+router.setRoutes(routes);
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,12 +78,6 @@
             "minimist": "^1.2.0"
           }
         },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -993,9 +987,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
-      "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==",
+      "version": "12.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
+      "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ==",
       "dev": true
     },
     "@vaadin/flow-deps": {
@@ -1013,13 +1007,13 @@
         "@vaadin/vaadin-confirm-dialog": "1.1.4",
         "@vaadin/vaadin-context-menu": "4.3.12",
         "@vaadin/vaadin-cookie-consent": "1.1.1",
-        "@vaadin/vaadin-core-shrinkwrap": "14.0.0",
+        "@vaadin/vaadin-core-shrinkwrap": "14.0.3",
         "@vaadin/vaadin-crud": "1.0.5",
         "@vaadin/vaadin-date-picker": "4.0.3",
         "@vaadin/vaadin-details": "1.0.1",
         "@vaadin/vaadin-dialog": "2.2.1",
-        "@vaadin/vaadin-form-layout": "2.1.4",
-        "@vaadin/vaadin-grid": "5.4.6",
+        "@vaadin/vaadin-form-layout": "2.1.6",
+        "@vaadin/vaadin-grid": "5.4.8",
         "@vaadin/vaadin-grid-pro": "2.0.3",
         "@vaadin/vaadin-icons": "4.3.1",
         "@vaadin/vaadin-item": "2.1.0",
@@ -1034,12 +1028,21 @@
         "@vaadin/vaadin-radio-button": "1.2.3",
         "@vaadin/vaadin-rich-text-editor": "1.0.4",
         "@vaadin/vaadin-select": "2.1.5",
-        "@vaadin/vaadin-shrinkwrap": "14.0.0",
+        "@vaadin/vaadin-shrinkwrap": "14.0.3",
         "@vaadin/vaadin-split-layout": "4.1.1",
         "@vaadin/vaadin-tabs": "3.0.4",
-        "@vaadin/vaadin-text-field": "2.4.8",
+        "@vaadin/vaadin-text-field": "2.4.11",
         "@vaadin/vaadin-time-picker": "2.0.2",
         "@vaadin/vaadin-upload": "4.2.2"
+      }
+    },
+    "@vaadin/router": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@vaadin/router/-/router-1.4.1.tgz",
+      "integrity": "sha512-TuEU92zQqjyyNELWEKX6ZmjTMPXNpPYtzimU7yhCVh6nktccxTnav+c6qARISu1mHeSy9HO74upXe1UKqtJ3/A==",
+      "requires": {
+        "@vaadin/vaadin-usage-statistics": "^2.0.8",
+        "path-to-regexp": "2.4.0"
       }
     },
     "@vaadin/vaadin-accordion": {
@@ -1192,9 +1195,9 @@
       }
     },
     "@vaadin/vaadin-core-shrinkwrap": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-core-shrinkwrap/-/vaadin-core-shrinkwrap-14.0.0.tgz",
-      "integrity": "sha512-3ht4tAIiuxFTuncaOkissYZZaiUdwdXVLtnG/Er3HEfoShk0Yhs5EJ/s1v5Ezfn1JI959Wgct5TFSo3UO+XBGg==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-core-shrinkwrap/-/vaadin-core-shrinkwrap-14.0.3.tgz",
+      "integrity": "sha512-U3KyslhfDYuw4zkqWN+KdvKLaS2YTF7SYZx0zgA+rjGjZX9i2NOnfttaeanBXHygkOTus8CJUq92mE7VuglEHg==",
       "requires": {
         "@polymer/iron-a11y-announcer": "^3.0.2",
         "@polymer/iron-a11y-keys-behavior": "^3.0.1",
@@ -1221,8 +1224,8 @@
         "@vaadin/vaadin-development-mode-detector": "^2.0.4",
         "@vaadin/vaadin-dialog": "^2.2.1",
         "@vaadin/vaadin-element-mixin": "^2.1.3",
-        "@vaadin/vaadin-form-layout": "^2.1.4",
-        "@vaadin/vaadin-grid": "^5.4.6",
+        "@vaadin/vaadin-form-layout": "^2.1.6",
+        "@vaadin/vaadin-grid": "^5.4.8",
         "@vaadin/vaadin-icons": "^4.3.1",
         "@vaadin/vaadin-item": "^2.1.1",
         "@vaadin/vaadin-list-box": "^1.1.1",
@@ -1239,11 +1242,11 @@
         "@vaadin/vaadin-select": "^2.1.5",
         "@vaadin/vaadin-split-layout": "^4.1.1",
         "@vaadin/vaadin-tabs": "^3.0.4",
-        "@vaadin/vaadin-text-field": "^2.4.8",
+        "@vaadin/vaadin-text-field": "^2.4.11",
         "@vaadin/vaadin-themable-mixin": "^1.4.4",
         "@vaadin/vaadin-time-picker": "^2.0.2",
         "@vaadin/vaadin-upload": "^4.2.2",
-        "@vaadin/vaadin-usage-statistics": "^2.0.4",
+        "@vaadin/vaadin-usage-statistics": "^2.0.9",
         "@webcomponents/shadycss": "^1.8.0"
       },
       "dependencies": {
@@ -1530,9 +1533,9 @@
           }
         },
         "@vaadin/vaadin-form-layout": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-form-layout/-/vaadin-form-layout-2.1.4.tgz",
-          "integrity": "sha512-zCeCJOMLpAP0jIkK50l547qjwx46LGML31oRUApwU1sv3YecQW6iMX+evdZWfzqIrx8T4yHPZks8Fx+5EjCSRg==",
+          "version": "2.1.6",
+          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-form-layout/-/vaadin-form-layout-2.1.6.tgz",
+          "integrity": "sha512-NINQT5c+z83jy7bQqAgghXfmHjTjlGSxZ64uboydgCxL7lCwkQ7CosDBxqXSEdsBVaXaucdAm6EOZJyr4a8zYQ==",
           "requires": {
             "@polymer/iron-resizable-behavior": "^3.0.0",
             "@polymer/polymer": "^3.0.0",
@@ -1543,9 +1546,9 @@
           }
         },
         "@vaadin/vaadin-grid": {
-          "version": "5.4.6",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-grid/-/vaadin-grid-5.4.6.tgz",
-          "integrity": "sha512-dWQlQvht7IqFxZNT6GLFyn7hUk57BeSZ4BKvYYzHOmRj7Av9ka7vRusEzHEr954klaHjjs9YDrPKrWWLK4qjNQ==",
+          "version": "5.4.8",
+          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-grid/-/vaadin-grid-5.4.8.tgz",
+          "integrity": "sha512-1N7sNM5WkPk0JjGGBaaGn3GanJpkE6ysUsUephqmBJSMFa3xLq2iGslxKeKUMOjbijSw5085rAvzLnDbjDJUCA==",
           "requires": {
             "@polymer/iron-a11y-announcer": "^3.0.0",
             "@polymer/iron-a11y-keys-behavior": "^3.0.0",
@@ -1760,9 +1763,9 @@
           }
         },
         "@vaadin/vaadin-text-field": {
-          "version": "2.4.8",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-text-field/-/vaadin-text-field-2.4.8.tgz",
-          "integrity": "sha512-7RsLX/xHimlXXdBgaQjtDWtNwQXo4Vh2fKbLC0y0lNAL/rb533mQH1iJPrsIXpwFcy4Yq2uZ5U4AYBftDcBg4g==",
+          "version": "2.4.11",
+          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-text-field/-/vaadin-text-field-2.4.11.tgz",
+          "integrity": "sha512-3AOfU7WBQjqQTnPS9SiVAXcTYmYWoKYciwEeWpRNfr+njrzy5ymQZlCUz1dfzF5+zVaz6W4Cbxd76TbTmQn68w==",
           "requires": {
             "@polymer/polymer": "^3.0.0",
             "@vaadin/vaadin-control-state-mixin": "^2.1.1",
@@ -1811,9 +1814,9 @@
           }
         },
         "@vaadin/vaadin-usage-statistics": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.0.4.tgz",
-          "integrity": "sha512-W954k2x0cy7YSNgvm6g3DukjPUCf6z2V0BsMMPz2masVP34MCi8p9JUvf8FsxABx34U6TCMouxCnNXQaFxX8Og==",
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.0.9.tgz",
+          "integrity": "sha512-O/snTfWKNYVM37KuzmUSjxKjLHOij1Oo5stFG4yfL68NyXIJIpZqJla5LGc/hHXEIf9ok2DmFUmnmEUKF1CGMQ==",
           "requires": {
             "@vaadin/vaadin-development-mode-detector": "^2.0.0"
           }
@@ -1906,9 +1909,9 @@
       }
     },
     "@vaadin/vaadin-form-layout": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-form-layout/-/vaadin-form-layout-2.1.4.tgz",
-      "integrity": "sha512-zCeCJOMLpAP0jIkK50l547qjwx46LGML31oRUApwU1sv3YecQW6iMX+evdZWfzqIrx8T4yHPZks8Fx+5EjCSRg==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-form-layout/-/vaadin-form-layout-2.1.6.tgz",
+      "integrity": "sha512-NINQT5c+z83jy7bQqAgghXfmHjTjlGSxZ64uboydgCxL7lCwkQ7CosDBxqXSEdsBVaXaucdAm6EOZJyr4a8zYQ==",
       "requires": {
         "@polymer/iron-resizable-behavior": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
@@ -1919,9 +1922,9 @@
       }
     },
     "@vaadin/vaadin-grid": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-grid/-/vaadin-grid-5.4.6.tgz",
-      "integrity": "sha512-dWQlQvht7IqFxZNT6GLFyn7hUk57BeSZ4BKvYYzHOmRj7Av9ka7vRusEzHEr954klaHjjs9YDrPKrWWLK4qjNQ==",
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-grid/-/vaadin-grid-5.4.8.tgz",
+      "integrity": "sha512-1N7sNM5WkPk0JjGGBaaGn3GanJpkE6ysUsUephqmBJSMFa3xLq2iGslxKeKUMOjbijSw5085rAvzLnDbjDJUCA==",
       "requires": {
         "@polymer/iron-a11y-announcer": "^3.0.0",
         "@polymer/iron-a11y-keys-behavior": "^3.0.0",
@@ -1977,9 +1980,9 @@
       }
     },
     "@vaadin/vaadin-license-checker": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-license-checker/-/vaadin-license-checker-2.1.0.tgz",
-      "integrity": "sha512-IEktFu6Ntx77uVyqz0boSpY+BrUvXXGfw6iGXmSRpEd0rmj1IgPQmNtAMEemEvD6lZsnCd8gimZZMb6eZVZmVA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-license-checker/-/vaadin-license-checker-2.1.1.tgz",
+      "integrity": "sha512-jmCL+o5QvUcp84+9lVb0208ocWlQx4cdC4UoXGdLQaeTdZkCVybDzcNUGH9Paz27P1Z5VXZ1j7lVy/CKIEAp9w==",
       "requires": {
         "@vaadin/vaadin-development-mode-detector": "^2.0.0"
       }
@@ -2079,9 +2082,9 @@
       }
     },
     "@vaadin/vaadin-overlay": {
-      "version": "3.2.13",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-overlay/-/vaadin-overlay-3.2.13.tgz",
-      "integrity": "sha512-QKMvmrHgJ8yCwS1O/VGc5Fdv4EZYdaFg115dfceLs3TJvicwFsLJjCzr/11rw2NwlVDZLDxodofqRIioByso9w==",
+      "version": "3.2.14",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-overlay/-/vaadin-overlay-3.2.14.tgz",
+      "integrity": "sha512-fBGxduRJX9ZPMflBwIDY1tqaavMEljqc6qO7zELvJdE3Kemk+6/SGxD1Aav7+P1CpkVHWV11S7LEQay9ssJt6Q==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-lumo-styles": "^1.3.0",
@@ -2151,9 +2154,9 @@
       }
     },
     "@vaadin/vaadin-shrinkwrap": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-shrinkwrap/-/vaadin-shrinkwrap-14.0.0.tgz",
-      "integrity": "sha512-3mIvQgfUmv4L/cV1xGDnKiWfGUdbHGZOr0KomnyjzsSDMEDc3ef0v+V6BJr7by3I7fqwLFfsC9BJQsxEvFk+iA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-shrinkwrap/-/vaadin-shrinkwrap-14.0.3.tgz",
+      "integrity": "sha512-pBFVEtS1zs1i9LHziAU2M0tylEVvoBHEHihvH9VDUXtXxN7U84gcP06K98xR64yS7vrb0WCrgMkyIf4fR2I4hA==",
       "requires": {
         "@polymer/iron-a11y-announcer": "^3.0.2",
         "@polymer/iron-a11y-keys-behavior": "^3.0.1",
@@ -2185,8 +2188,8 @@
         "@vaadin/vaadin-development-mode-detector": "^2.0.4",
         "@vaadin/vaadin-dialog": "^2.2.1",
         "@vaadin/vaadin-element-mixin": "^2.1.3",
-        "@vaadin/vaadin-form-layout": "^2.1.4",
-        "@vaadin/vaadin-grid": "^5.4.6",
+        "@vaadin/vaadin-form-layout": "^2.1.6",
+        "@vaadin/vaadin-grid": "^5.4.8",
         "@vaadin/vaadin-grid-pro": "^2.0.3",
         "@vaadin/vaadin-icons": "^4.3.1",
         "@vaadin/vaadin-item": "^2.1.1",
@@ -2205,11 +2208,11 @@
         "@vaadin/vaadin-select": "^2.1.5",
         "@vaadin/vaadin-split-layout": "^4.1.1",
         "@vaadin/vaadin-tabs": "^3.0.4",
-        "@vaadin/vaadin-text-field": "^2.4.8",
+        "@vaadin/vaadin-text-field": "^2.4.11",
         "@vaadin/vaadin-themable-mixin": "^1.4.4",
         "@vaadin/vaadin-time-picker": "^2.0.2",
         "@vaadin/vaadin-upload": "^4.2.2",
-        "@vaadin/vaadin-usage-statistics": "^2.0.4",
+        "@vaadin/vaadin-usage-statistics": "^2.0.9",
         "@webcomponents/shadycss": "^1.8.0"
       },
       "dependencies": {
@@ -2568,9 +2571,9 @@
           }
         },
         "@vaadin/vaadin-form-layout": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-form-layout/-/vaadin-form-layout-2.1.4.tgz",
-          "integrity": "sha512-zCeCJOMLpAP0jIkK50l547qjwx46LGML31oRUApwU1sv3YecQW6iMX+evdZWfzqIrx8T4yHPZks8Fx+5EjCSRg==",
+          "version": "2.1.6",
+          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-form-layout/-/vaadin-form-layout-2.1.6.tgz",
+          "integrity": "sha512-NINQT5c+z83jy7bQqAgghXfmHjTjlGSxZ64uboydgCxL7lCwkQ7CosDBxqXSEdsBVaXaucdAm6EOZJyr4a8zYQ==",
           "requires": {
             "@polymer/iron-resizable-behavior": "^3.0.0",
             "@polymer/polymer": "^3.0.0",
@@ -2581,9 +2584,9 @@
           }
         },
         "@vaadin/vaadin-grid": {
-          "version": "5.4.6",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-grid/-/vaadin-grid-5.4.6.tgz",
-          "integrity": "sha512-dWQlQvht7IqFxZNT6GLFyn7hUk57BeSZ4BKvYYzHOmRj7Av9ka7vRusEzHEr954klaHjjs9YDrPKrWWLK4qjNQ==",
+          "version": "5.4.8",
+          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-grid/-/vaadin-grid-5.4.8.tgz",
+          "integrity": "sha512-1N7sNM5WkPk0JjGGBaaGn3GanJpkE6ysUsUephqmBJSMFa3xLq2iGslxKeKUMOjbijSw5085rAvzLnDbjDJUCA==",
           "requires": {
             "@polymer/iron-a11y-announcer": "^3.0.0",
             "@polymer/iron-a11y-keys-behavior": "^3.0.0",
@@ -2841,9 +2844,9 @@
           }
         },
         "@vaadin/vaadin-text-field": {
-          "version": "2.4.8",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-text-field/-/vaadin-text-field-2.4.8.tgz",
-          "integrity": "sha512-7RsLX/xHimlXXdBgaQjtDWtNwQXo4Vh2fKbLC0y0lNAL/rb533mQH1iJPrsIXpwFcy4Yq2uZ5U4AYBftDcBg4g==",
+          "version": "2.4.11",
+          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-text-field/-/vaadin-text-field-2.4.11.tgz",
+          "integrity": "sha512-3AOfU7WBQjqQTnPS9SiVAXcTYmYWoKYciwEeWpRNfr+njrzy5ymQZlCUz1dfzF5+zVaz6W4Cbxd76TbTmQn68w==",
           "requires": {
             "@polymer/polymer": "^3.0.0",
             "@vaadin/vaadin-control-state-mixin": "^2.1.1",
@@ -2892,9 +2895,9 @@
           }
         },
         "@vaadin/vaadin-usage-statistics": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.0.4.tgz",
-          "integrity": "sha512-W954k2x0cy7YSNgvm6g3DukjPUCf6z2V0BsMMPz2masVP34MCi8p9JUvf8FsxABx34U6TCMouxCnNXQaFxX8Og==",
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.0.9.tgz",
+          "integrity": "sha512-O/snTfWKNYVM37KuzmUSjxKjLHOij1Oo5stFG4yfL68NyXIJIpZqJla5LGc/hHXEIf9ok2DmFUmnmEUKF1CGMQ==",
           "requires": {
             "@vaadin/vaadin-development-mode-detector": "^2.0.0"
           }
@@ -2945,9 +2948,9 @@
       }
     },
     "@vaadin/vaadin-text-field": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-text-field/-/vaadin-text-field-2.4.8.tgz",
-      "integrity": "sha512-7RsLX/xHimlXXdBgaQjtDWtNwQXo4Vh2fKbLC0y0lNAL/rb533mQH1iJPrsIXpwFcy4Yq2uZ5U4AYBftDcBg4g==",
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-text-field/-/vaadin-text-field-2.4.11.tgz",
+      "integrity": "sha512-3AOfU7WBQjqQTnPS9SiVAXcTYmYWoKYciwEeWpRNfr+njrzy5ymQZlCUz1dfzF5+zVaz6W4Cbxd76TbTmQn68w==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-control-state-mixin": "^2.1.1",
@@ -2996,9 +2999,9 @@
       }
     },
     "@vaadin/vaadin-usage-statistics": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.0.8.tgz",
-      "integrity": "sha512-4CvEW7L5mEflXTL5sBxNnpSLAioU9A8ueK9FGzCFucD7aYEEOT9rVn+rAEpF91mR/kHJ3MQMWC8SdvATY+qLKQ==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.0.10.tgz",
+      "integrity": "sha512-j8bD1Ecl/UB3a2lgzS3j8nh/X2jfA38Pg74vTSepyE6OgzFggjWIyWrlrnQScQik5PkjHByKW4Cj33Rpt2Zm8g==",
       "requires": {
         "@vaadin/vaadin-development-mode-detector": "^2.0.0"
       }
@@ -3408,6 +3411,22 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "awesome-typescript-loader": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-5.2.1.tgz",
+      "integrity": "sha512-slv66OAJB8orL+UUaTI3pKlLorwIvS4ARZzYR9iJJyGsEgOqueMfOMdKySWzZ73vIkEe3fcwFgsKMg4d8zyb1g==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "enhanced-resolve": "^4.0.0",
+        "loader-utils": "^1.1.0",
+        "lodash": "^4.17.5",
+        "micromatch": "^3.1.9",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.5.3",
+        "webpack-log": "^1.2.0"
+      }
+    },
     "babel-loader": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
@@ -3690,14 +3709,14 @@
       }
     },
     "browserslist": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
-      "integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
+      "integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000984",
-        "electron-to-chromium": "^1.3.191",
-        "node-releases": "^1.1.25"
+        "caniuse-lite": "^1.0.30000989",
+        "electron-to-chromium": "^1.3.247",
+        "node-releases": "^1.1.29"
       }
     },
     "buffer": {
@@ -3815,9 +3834,9 @@
       }
     },
     "chokidar": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
-      "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
@@ -4120,6 +4139,18 @@
         "schema-utils": "^1.0.0",
         "serialize-javascript": "^1.7.0",
         "webpack-log": "^2.0.0"
+      },
+      "dependencies": {
+        "webpack-log": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+          "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "^3.0.0",
+            "uuid": "^3.3.2"
+          }
+        }
       }
     },
     "core-js": {
@@ -4247,6 +4278,16 @@
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
     },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -4275,10 +4316,18 @@
       "dev": true
     },
     "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
+      "integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+      "dev": true,
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -4540,15 +4589,15 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.225",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.225.tgz",
-      "integrity": "sha512-7W/L3jw7HYE+tUPbcVOGBmnSrlUmyZ/Uyg24QS7Vx0a9KodtNrN0r0Q/LyGHrcYMtw2rv7E49F/vTXwlV/fuaA==",
+      "version": "1.3.252",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.252.tgz",
+      "integrity": "sha512-NWJ5TztDnjExFISZHFwpoJjMbLUifsNBnx7u2JI0gCw6SbKyQYYWWtBHasO/jPtHym69F4EZuTpRNGN11MT/jg==",
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
-      "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
+      "integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -4609,18 +4658,22 @@
       }
     },
     "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.1.tgz",
+      "integrity": "sha512-cp/Tb1oA/rh2X7vqeSOvM+TSo3UkJLX70eNihgVEvnzwAgikjkTFr/QVgRCaxjm0knCNQzNoxxxcw2zO2LJdZA==",
       "dev": true,
       "optional": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-symbols": "^1.0.0",
         "is-callable": "^1.1.4",
         "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
+        "object-inspect": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "string.prototype.trimleft": "^2.0.0",
+        "string.prototype.trimright": "^2.0.0"
       }
     },
     "es-to-primitive": {
@@ -4633,6 +4686,38 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.51",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz",
+      "integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "^1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.2.tgz",
+      "integrity": "sha512-/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==",
+      "dev": true,
+      "requires": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.51"
       }
     },
     "escape-html": {
@@ -4816,6 +4901,12 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
           "dev": true
         }
       }
@@ -5025,12 +5116,12 @@
       }
     },
     "follow-redirects": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
-      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.8.1.tgz",
+      "integrity": "sha512-micCIbldHioIegeKs41DoH0KS3AXfFzgS30qVkM6z/XOE/GJgvmsoc839NUqa1B9udYe9dQxgv7KFwng6+p/dw==",
       "dev": true,
       "requires": {
-        "debug": "^3.2.6"
+        "debug": "^3.0.0"
       },
       "dependencies": {
         "debug": {
@@ -5790,7 +5881,6 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -6217,6 +6307,12 @@
         }
       }
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
+    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -6263,8 +6359,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -6376,7 +6471,6 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
-      "optional": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -6470,14 +6564,6 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "killable": {
@@ -6534,11 +6620,30 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
+    },
     "loglevel": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz",
       "integrity": "sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==",
       "dev": true
+    },
+    "loglevelnext": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/loglevelnext/-/loglevelnext-1.0.5.tgz",
+      "integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
+      "dev": true,
+      "requires": {
+        "es6-symbol": "^3.1.1",
+        "object.assign": "^4.1.0"
+      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -6735,9 +6840,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
     "mississippi": {
@@ -6786,6 +6891,14 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
       }
     },
     "move-concurrently": {
@@ -6862,6 +6975,12 @@
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -6924,9 +7043,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.27.tgz",
-      "integrity": "sha512-9iXUqHKSGo6ph/tdXVbHFbhRVQln4ZDTIBJCzsa90HimnBYc5jw8RWYt4wBYFHehGyC3koIz5O4mb2fHrbPOuA==",
+      "version": "1.1.29",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.29.tgz",
+      "integrity": "sha512-R5bDhzh6I+tpi/9i2hrrvGJ3yKPYzlVOORDkXhnZuwi5D3q1I5w4vYy24PJXTcLk9Q0kws9TO77T75bcK8/ysQ==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -6999,6 +7118,19 @@
           }
         }
       }
+    },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "dev": true,
+      "optional": true
+    },
+    "object-is": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+      "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
@@ -7142,9 +7274,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -7273,10 +7405,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-      "dev": true
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w=="
     },
     "path-type": {
       "version": "3.0.0",
@@ -7339,9 +7470,9 @@
       }
     },
     "portfinder": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.21.tgz",
-      "integrity": "sha512-ESabpDCzmBS3ekHbmpAIiESq3udRsCBGiBZLsC+HgBKv2ezb0R4oG+7RnYEVZ/ZCfhel5Tx3UzdNWA0Lox2QCA==",
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.23.tgz",
+      "integrity": "sha512-B729mL/uLklxtxuiJKfQ84WPxNw5a7Yhx3geQZdcA4GjNjZSTSSMMWyoennMVnTWSmAR0lMdzWYN0JLnHrg1KQ==",
       "dev": true,
       "requires": {
         "async": "^1.5.2",
@@ -7605,10 +7736,19 @@
       }
     },
     "regexp-tree": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.11.tgz",
-      "integrity": "sha512-7/l/DgapVVDzZobwMCCgMlqiqyLFJ0cduo/j+3BcDJIB+yJdsYCfKuI3l/04NV+H/rfNRdPIDbXNZHM9XvQatg==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.13.tgz",
+      "integrity": "sha512-hwdV/GQY5F8ReLZWO+W1SRoN5YfpOKY6852+tBFcma72DKBIcHjPRIlIvQN35bCOljuAfP2G2iB0FC/w236mUw==",
       "dev": true
+    },
+    "regexp.prototype.flags": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2"
+      }
     },
     "regexpu-core": {
       "version": "4.5.5",
@@ -7751,9 +7891,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.0.tgz",
-      "integrity": "sha512-4Liqw7ccABzsWV5BzeZeGRSq7KWIgQYzOcmRDEwSX4WAawlQpcAFXZ1Kid72XYrjSnK5yxOS6Gez/iGusYE/Pw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
@@ -7861,9 +8001,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
-      "integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
+      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
       "dev": true
     },
     "serve-index": {
@@ -8386,6 +8526,28 @@
         }
       }
     },
+    "string.prototype.trimleft": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.0.0.tgz",
+      "integrity": "sha1-aLaqjhYsaoDnbjqKDC50cYbicf8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.0.2"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.0.0.tgz",
+      "integrity": "sha1-q0pW2AKgH75yk+EehPJNyBZGYd0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.0.2"
+      }
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -8426,9 +8588,9 @@
       "dev": true
     },
     "terser": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.4.tgz",
-      "integrity": "sha512-+ZwXJvdSwbd60jG0Illav0F06GDJF0R4ydZ21Q3wGAFKoBGyJGo34F63vzJHgvYxc1ukOtIjvwEvl9MkjzM6Pg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.2.1.tgz",
+      "integrity": "sha512-cGbc5utAcX4a9+2GGVX4DsenG6v0x3glnDi5hx8816X1McEAwPlPgRtXPJzSBsbpILxZ8MQMT0KvArLuE0HP5A==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -8462,9 +8624,9 @@
       },
       "dependencies": {
         "cacache": {
-          "version": "12.0.2",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.2.tgz",
-          "integrity": "sha512-ifKgxH2CKhJEg6tNdAwziu6Q33EvuG26tYcda6PT3WKisZcYDXsnEdnRv67Po3yCzFfaSoMjGZzJyD2c3DT1dg==",
+          "version": "12.0.3",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+          "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
           "dev": true,
           "requires": {
             "bluebird": "^3.5.5",
@@ -8602,6 +8764,12 @@
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
+    "type": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
+      "integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg==",
+      "dev": true
+    },
     "type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -8616,6 +8784,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "uglify-js": {
@@ -8750,9 +8924,9 @@
       }
     },
     "upath": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
-      "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
       "dev": true
     },
     "upper-case": {
@@ -8859,9 +9033,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
       "dev": true
     },
     "v8-compile-cache": {
@@ -8974,13 +9148,14 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.0.tgz",
-      "integrity": "sha512-qvDesR1QZRIAZHOE3iQ4CXLZZSQ1lAUsSpnQmlB1PBfoN/xdRjmge3Dok0W4IdaVLJOGJy3sGI4sZHwjRU0PCA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.1.tgz",
+      "integrity": "sha512-5MWu9SH1z3hY7oHOV6Kbkz5x7hXbxK56mGHNqHTe6d+ewxOwKUxoUJBs7QIaJb33lPjl9bJZ3X0vCoooUzC36A==",
       "dev": true,
       "requires": {
         "memory-fs": "^0.4.1",
-        "mime": "^2.4.2",
+        "mime": "^2.4.4",
+        "mkdirp": "^0.5.1",
         "range-parser": "^1.2.1",
         "webpack-log": "^2.0.0"
       },
@@ -8990,6 +9165,16 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
           "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
           "dev": true
+        },
+        "webpack-log": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+          "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "^3.0.0",
+            "uuid": "^3.3.2"
+          }
         }
       }
     },
@@ -9060,17 +9245,29 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
+        },
+        "webpack-log": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+          "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "^3.0.0",
+            "uuid": "^3.3.2"
+          }
         }
       }
     },
     "webpack-log": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
-      "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.2.0.tgz",
+      "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
       "dev": true,
       "requires": {
-        "ansi-colors": "^3.0.0",
-        "uuid": "^3.3.2"
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.1",
+        "uuid": "^3.1.0"
       }
     },
     "webpack-merge": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "@polymer/polymer": "3.2.0",
     "@webcomponents/webcomponentsjs": "^2.2.10",
-    "@vaadin/flow-deps": "./target/frontend"
+    "@vaadin/flow-deps": "./target/frontend",
+    "@vaadin/router": "^1.4.1"
   },
   "devDependencies": {
     "webpack": "4.30.0",
@@ -13,6 +14,8 @@
     "webpack-babel-multi-target-plugin": "2.1.0",
     "copy-webpack-plugin": "5.0.3",
     "webpack-merge": "4.2.1",
-    "raw-loader": "3.0.0"
+    "raw-loader": "3.0.0",
+    "typescript": "3.5.3",
+    "awesome-typescript-loader": "5.2.1"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,11 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <vaadin.version>14.0.3</vaadin.version>
+        <flow.version>3.0.0.alpha1</flow.version>
 
         <drivers.dir>${project.basedir}/drivers</drivers.dir>
         <drivers.downloader.phase>pre-integration-test</drivers.downloader.phase>
+        <vaadin.clientSideMode>true</vaadin.clientSideMode>
     </properties>
 
     <parent>
@@ -27,19 +29,24 @@
         <version>2.1.7.RELEASE</version>
     </parent>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>central</id>
-            <url>https://repo1.maven.org/maven2/</url>
-            <snapshots><enabled>false</enabled></snapshots>
-        </pluginRepository>
-    </pluginRepositories>
-
     <repositories>
+        <!-- The order of definitions matters. Explicitly defining central here to make sure it has the highest priority. -->
+
+        <!-- Main Maven repository -->
         <repository>
             <id>central</id>
             <url>https://repo1.maven.org/maven2/</url>
             <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+        <!-- The current version of Flow 3.0 is a pre-release version, so vaadin-prereleases repository is needed. -->
+        <repository>
+            <id>vaadin-prereleases</id>
+            <url>
+                https://maven.vaadin.com/vaadin-prereleases/
+            </url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
         <!-- Repository used by many Vaadin add-ons -->
         <repository>
@@ -48,6 +55,24 @@
             <snapshots><enabled>false</enabled></snapshots>
         </repository>
     </repositories>
+
+    <pluginRepositories>
+        <!-- Main Maven repository -->
+        <pluginRepository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2/</url>
+            <snapshots><enabled>false</enabled></snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>vaadin-prereleases</id>
+            <url>
+                https://maven.vaadin.com/vaadin-prereleases/
+            </url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 
     <dependencyManagement>
         <dependencies>
@@ -96,6 +121,16 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-client</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spring-boot-starter</artifactId>
             <exclusions>
                 <!-- Excluding so that webjars are not included. -->
@@ -130,8 +165,8 @@
             -->
             <plugin>
                 <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-maven-plugin</artifactId>
-                <version>${vaadin.version}</version>
+                <artifactId>flow-maven-plugin</artifactId>
+                <version>${flow.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -169,7 +204,7 @@
                     </plugin>
                     <plugin>
                         <groupId>com.vaadin</groupId>
-                        <artifactId>vaadin-maven-plugin</artifactId>
+                        <artifactId>flow-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <goals>

--- a/src/test/java/com/vaadin/starter/skeleton/spring/AbstractViewTest.java
+++ b/src/test/java/com/vaadin/starter/skeleton/spring/AbstractViewTest.java
@@ -11,6 +11,7 @@ import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.testbench.ScreenshotOnFailureRule;
 import com.vaadin.testbench.TestBench;
 import com.vaadin.testbench.parallel.ParallelTest;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 /**
  * Base class for TestBench IntegrationTests on chrome.
@@ -37,7 +38,7 @@ public abstract class AbstractViewTest extends ParallelTest {
             false);
 
     public AbstractViewTest() {
-        this("", By.tagName("body"));
+        this("", By.cssSelector("#outlet > :first-child"));
     }
 
     protected AbstractViewTest(String route, By rootSelector) {
@@ -53,6 +54,7 @@ public abstract class AbstractViewTest extends ParallelTest {
             setDriver(TestBench.createDriver(new ChromeDriver()));
         }
         getDriver().get(getURL(route));
+        waitUntil(ExpectedConditions.presenceOfElementLocated(this.rootSelector));
     }
 
     /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "inlineSources": true,
+    "module": "esNext",
+    "target": "es2017",
+    "moduleResolution": "node",
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "experimentalDecorators": true
+  },
+  "include": [
+    "frontend/**/*.ts", "frontend/index.js"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
CCDM: Add client-side bootstrap and routing facilities

Fixes #216

This change enables adding client-side views and using client-side routing with a fallback to server-side Flow application.

Brief list of changes:

- Depend on Flow v3.0.0.alpha1 pre-release
- Enable vaadin.clientSideMode in pom.xml
- Add tsconfig.json
- Add `index.html` page source, and `index.ts` main entrypoint
- Import and setup Flow client-side client in `index.ts`
- Add `@vaadin/router` dependency to package.json
- Use Vaadin Router as a client-side router in `index.ts`
- Make the client-side router fallback to the Flow’s server-side routing
- Enable Travis CI build for the `ccdm` branch
- Adjust IT tests to wait until first render

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-spring/219)
<!-- Reviewable:end -->
