### PR TITLE
CCDM: Replace Polymer dependency with LitElement, add an empty main layout

### DIFF
--- a/frontend/index.ts
+++ b/frontend/index.ts
@@ -1,6 +1,8 @@
 import {Flow} from '@vaadin/flow-frontend/Flow';
 import {Router} from '@vaadin/router';
 
+import './main-layout';
+
 const flow = new Flow({
   // @ts-ignore
   imports: () => import('../target/frontend/generated-flow-imports')
@@ -8,12 +10,18 @@ const flow = new Flow({
 
 const routes = [
   {
-    // fallback to server-side Flow routes if no client-side routes match
-    path: '(.*)',
+    path: '',
+    component: 'main-layout',
+    children: [
+      {
+        // fallback to server-side Flow routes if no client-side routes match
+        path: '(.*)',
 
-    // FIXME: replace flow.navigate with flow.route()
-    // when https://github.com/vaadin/flow/issues/6338 is implemented
-    action: flow.navigate as any
+        // FIXME: replace flow.navigate with flow.route()
+        // when https://github.com/vaadin/flow/issues/6338 is implemented
+        action: flow.navigate as any
+      }
+    ]
   }
 ];
 

--- a/frontend/main-layout.ts
+++ b/frontend/main-layout.ts
@@ -1,0 +1,16 @@
+import {LitElement, html, css, customElement} from 'lit-element';
+
+@customElement('main-layout')
+export class MainLayoutElement extends LitElement {
+  static get styles() {
+    return css`
+      :host {
+        display: block;
+      }
+    `;
+  }
+
+  render() {
+    return html`<slot></slot>`;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6587,6 +6587,19 @@
         "invert-kv": "^2.0.0"
       }
     },
+    "lit-element": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.2.1.tgz",
+      "integrity": "sha512-ipDcgQ1EpW6Va2Z6dWm79jYdimVepO5GL0eYkZrFvdr0OD/1N260Q9DH+K5HXHFrRoC7dOg+ZpED2XE0TgGdXw==",
+      "requires": {
+        "lit-html": "^1.0.0"
+      }
+    },
+    "lit-html": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.1.2.tgz",
+      "integrity": "sha512-FFlUMKHKi+qG1x1iHNZ1hrtc/zHmfYTyrSvs3/wBTvaNtpZjOZGWzU7efGYVpgp6KvWeKF6ql9/KsCq6Z/mEDA=="
+    },
     "loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "no-name",
   "license": "UNLICENSED",
   "dependencies": {
-    "@polymer/polymer": "3.2.0",
-    "@webcomponents/webcomponentsjs": "^2.2.10",
     "@vaadin/flow-deps": "./target/frontend",
-    "@vaadin/router": "^1.4.1"
+    "@vaadin/router": "^1.4.1",
+    "@webcomponents/webcomponentsjs": "^2.2.10",
+    "lit-element": "^2.2.1"
   },
   "devDependencies": {
     "webpack": "4.30.0",


### PR DESCRIPTION
The idea so far is to use LitElement as a base for frontend views. To
support that, this change:

- replaces Polymer dependency with LitElement,

- adds an empty main layout element based on LitElement,

- adds a root-level client side route for the main layout.