### PR TITLE
CCDM: use serverSiceRoutes API, and latest versions

### DIFF
--- a/frontend/index.ts
+++ b/frontend/index.ts
@@ -1,14 +1,14 @@
 import {Flow} from '@vaadin/flow-frontend/Flow';
 import {Router} from '@vaadin/router';
 
-const flow = new Flow({
+const {serverSideRoutes} = new Flow({
   // @ts-ignore
   imports: () => import('../target/frontend/generated-flow-imports')
 });
 
 const routes = [
   // fallback to server-side Flow routes if no client-side routes match
-  flow.route
+  ...serverSideRoutes
 ];
 
 const router = new Router(document.querySelector('#outlet'));

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "raw-loader": "3.0.0",
     "typescript": "3.5.3",
     "awesome-typescript-loader": "5.2.1",
-    "compression-webpack-plugin": "3.0.0"
+    "compression-webpack-plugin": "3.0.0",
+    "html-webpack-plugin": "3.2.0"
   },
   "vaadinAppPackageHash": "bfa56a3401120d19ebf20b1c76af890ee925bbd1ab0da40402542a858d6ca01a"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <vaadin.version>14.0.5</vaadin.version>
-        <flow.version>3.0.0.alpha3</flow.version>
+        <vaadin.version>14.0.7</vaadin.version>
+        <flow.version>3.0.0.alpha4</flow.version>
 
         <drivers.dir>${project.basedir}/drivers</drivers.dir>
         <drivers.downloader.phase>pre-integration-test</drivers.downloader.phase>


### PR DESCRIPTION
Connected to https://github.com/vaadin/flow/issues/6580

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-spring/233)
<!-- Reviewable:end -->
