### PR TITLE
CCDM: update frontend directory structure and READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# Project Base for Vaadin Flow and Spring Boot
+# Project Base for Vaadin and Spring Boot
 
-This project can be used as a starting point to create your own Vaadin Flow application with Spring Boot.
+This project can be used as a starting point to create your own Vaadin application with Spring Boot.
 It contains all the necessary configuration and some placeholder files to get you started.
 
 The best way to use it by via [vaadin.com/start](https://vaadin.com/start) - you can get only the necessary parts and choose the package naming you want to use.
+
+## Running the Application
 
 Import the project to the IDE of your choosing as a Maven project. 
 
@@ -13,7 +15,24 @@ Open http://localhost:8080/ in browser
 
 If you want to run your app locally in the production mode, run `mvn spring-boot:run -Pproduction`.
 
-For documentation on using Vaadin Flow and Spring, visit [vaadin.com/docs](https://vaadin.com/docs/flow/spring/tutorial-spring-basic.html)
+## Structure
 
-For more information on Vaadin Flow, visit https://vaadin.com/flow.
+Vaadin web applications are full-stack and include both client-side and server-side code in the same project.
+
+| Directory | Description |
+| :--- | :--- |
+| `frontend/` | Client-side source directory |
+| &nbsp;&nbsp;&nbsp;&nbsp;`index.html` | HTML template |
+| &nbsp;&nbsp;&nbsp;&nbsp;`index.ts` | Frontend entrypoint |
+| &nbsp;&nbsp;&nbsp;&nbsp;`main-layout.ts` | Main layout Web Component (optional) |
+| &nbsp;&nbsp;&nbsp;&nbsp;`views/` | UI views Web Components (TypeScript / HTML) |
+| &nbsp;&nbsp;&nbsp;&nbsp;`styles/` | Styles directory (CSS) |
+| `src/main/java/<groupId>/` | Server-side source directory |
+| &nbsp;&nbsp;&nbsp;&nbsp;`Application.java` | Server entrypoint |
+
+## More Information
+
+<!-- FIXME: Use a link from vaadin.com -->
+- [Quick Start Guide](https://github.com/vaadin/flow-and-components-documentation/blob/ccdm/documentation/ccdm/quick-start-guide.asciidoc) for Vaadin client-side applications
+- [Vaadin Flow](https://vaadin.com/flow) website
 

--- a/frontend/index.ts
+++ b/frontend/index.ts
@@ -2,7 +2,6 @@ import {Flow} from '@vaadin/flow-frontend/Flow';
 import {Router} from '@vaadin/router';
 
 const {serverSideRoutes} = new Flow({
-  // @ts-ignore
   imports: () => import('../target/frontend/generated-flow-imports')
 });
 

--- a/frontend/src/README
+++ b/frontend/src/README
@@ -1,1 +1,0 @@
-Place your Vaadin Designer or hand written templates in this folder.

--- a/frontend/styles/README
+++ b/frontend/styles/README
@@ -1,3 +1,1 @@
-Place your optional style modules in this folder.
-
-See https://vaadin.com/docs/flow/theme/theming-overview.html for getting started on theming Vaadin Flow applications.
+Place your CSS files in this directory.

--- a/frontend/views/README
+++ b/frontend/views/README
@@ -1,0 +1,3 @@
+Place your UI views in this directory.
+
+You can create them visually with Vaadin Designer or by hand in your IDE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1008,9 +1008,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.9.tgz",
-      "integrity": "sha512-P57oKTJ/vYivL2BCfxCC5tQjlS8qW31pbOL6qt99Yrjm95YdHgNZwjrTTjMBh+C2/y6PXIX4oz253+jUzxKKfQ==",
+      "version": "12.7.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.11.tgz",
+      "integrity": "sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==",
       "dev": true
     },
     "@vaadin/flow-deps": {
@@ -1029,13 +1029,12 @@
         "@vaadin/vaadin-context-menu": "4.3.12",
         "@vaadin/vaadin-cookie-consent": "1.1.1",
         "@vaadin/vaadin-crud": "1.0.5",
-        "@vaadin/vaadin-custom-field": "1.0.6",
         "@vaadin/vaadin-date-picker": "4.0.3",
         "@vaadin/vaadin-details": "1.0.1",
         "@vaadin/vaadin-dialog": "2.2.1",
         "@vaadin/vaadin-form-layout": "2.1.6",
         "@vaadin/vaadin-grid": "5.4.9",
-        "@vaadin/vaadin-grid-pro": "2.0.3",
+        "@vaadin/vaadin-grid-pro": "2.0.4",
         "@vaadin/vaadin-icons": "4.3.1",
         "@vaadin/vaadin-item": "2.1.0",
         "@vaadin/vaadin-list-box": "1.1.1",
@@ -1050,16 +1049,16 @@
         "@vaadin/vaadin-rich-text-editor": "1.0.4",
         "@vaadin/vaadin-select": "2.1.5",
         "@vaadin/vaadin-split-layout": "4.1.1",
-        "@vaadin/vaadin-tabs": "3.0.4",
-        "@vaadin/vaadin-text-field": "2.4.11",
+        "@vaadin/vaadin-tabs": "3.0.5",
+        "@vaadin/vaadin-text-field": "2.4.12",
         "@vaadin/vaadin-time-picker": "2.0.2",
         "@vaadin/vaadin-upload": "4.2.2"
       }
     },
     "@vaadin/router": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@vaadin/router/-/router-1.4.3.tgz",
-      "integrity": "sha512-a9pYrnmWXum2dmUTFsJ8ZkAkoUZIsfy8YM9VTWKWaatj+pKY4wApSbH1waf+YOF6FXsEEV4pMAaAS8ipisCpIQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/router/-/router-1.5.0.tgz",
+      "integrity": "sha512-MWrmkTuBBTT7NM+kNloYOJn/LYEft7cowU3K+EnXWisq3q2O7xgXhl3Ni2nC0pSMs8Gx470LAXfz3wCmqC7Hpw==",
       "requires": {
         "@vaadin/vaadin-usage-statistics": "^2.0.8",
         "path-to-regexp": "2.4.0"
@@ -1233,18 +1232,6 @@
         "@vaadin/vaadin-themable-mixin": "^1.4.4"
       }
     },
-    "@vaadin/vaadin-custom-field": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-custom-field/-/vaadin-custom-field-1.0.6.tgz",
-      "integrity": "sha512-OaiqNJS7HdHeGEZUxuYRCj3IY3h2+4V688vIOCawzojvwUGY35tucD1X7elqS3f8NmZLlauDPVUW09esuVtGTw==",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-element-mixin": "^2.0.0",
-        "@vaadin/vaadin-lumo-styles": "^1.3.3",
-        "@vaadin/vaadin-material-styles": "^1.2.2",
-        "@vaadin/vaadin-themable-mixin": "^1.2.0"
-      }
-    },
     "@vaadin/vaadin-date-picker": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-date-picker/-/vaadin-date-picker-4.0.3.tgz",
@@ -1338,9 +1325,9 @@
       }
     },
     "@vaadin/vaadin-grid-pro": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-grid-pro/-/vaadin-grid-pro-2.0.3.tgz",
-      "integrity": "sha512-wl6EZvtrUburomMtySzG1rTEiby4m6yZriAErJ9mJCIEIVHTBpGf6USympb9JsPi2pr3kenCCnKy9dIcWoAVug==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-grid-pro/-/vaadin-grid-pro-2.0.4.tgz",
+      "integrity": "sha512-9XUPmMvI8I5w9RAj3tagCTMqsJACeKZnhK9bFETI9J34FuP4vNGQ91o6akdhvZ5xJT6mwrm4cuzzfyQeOX89Qg==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-checkbox": "^2.2.1",
@@ -1400,9 +1387,9 @@
       }
     },
     "@vaadin/vaadin-list-mixin": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-list-mixin/-/vaadin-list-mixin-2.2.1.tgz",
-      "integrity": "sha512-63WuVvcai+sLbjPlBmjvI8O9obUCGKDDJwzPBmAaAv3EemyBwaavcBTpDkfWKEJAWU3tCFQmk4MSFsa3ZUCc0Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-list-mixin/-/vaadin-list-mixin-2.3.0.tgz",
+      "integrity": "sha512-IxoNDorwmLDecj51oQZQp/2Pr0+tf5z7SWr6vTQlbWrckd86eQs8vSdDhbW/OU2ZC9OsG1wN5we2ZtPj5P84Xw==",
       "requires": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -1565,9 +1552,9 @@
       }
     },
     "@vaadin/vaadin-tabs": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-tabs/-/vaadin-tabs-3.0.4.tgz",
-      "integrity": "sha512-FOVIec1BTT4THmsKX1cnTjQxHiYCxT9k/3q/ApL89mjrxW+dSvQnrVpadShh43x7omItOWyI1BsDx2zHcA/PEQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-tabs/-/vaadin-tabs-3.0.5.tgz",
+      "integrity": "sha512-ptCOJFwV3TN/csD0TRdr24tAIFyb/IuV8py3jcoMbgMwS3QiwOcpiQ+WRKoVCr87d8wBbIPN7CQ2bopFyYbCpA==",
       "requires": {
         "@polymer/iron-resizable-behavior": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
@@ -1580,9 +1567,9 @@
       }
     },
     "@vaadin/vaadin-text-field": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-text-field/-/vaadin-text-field-2.4.11.tgz",
-      "integrity": "sha512-3AOfU7WBQjqQTnPS9SiVAXcTYmYWoKYciwEeWpRNfr+njrzy5ymQZlCUz1dfzF5+zVaz6W4Cbxd76TbTmQn68w==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-text-field/-/vaadin-text-field-2.4.12.tgz",
+      "integrity": "sha512-ckrR12NoQslIiX32eSnwLeiq42412/PHbM3yNlkLhPpjOH7CSR8N4kivNR4JRmTDG50FXh34GUBh3gL9m4HQwA==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-control-state-mixin": "^2.1.1",
@@ -1593,9 +1580,9 @@
       }
     },
     "@vaadin/vaadin-themable-mixin": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-1.4.4.tgz",
-      "integrity": "sha512-S/zN0DvSQ3cy1PdH0Dfa2yQirIFQKWCC3o0YdBzrKVCGvi5QW8+IqBTDFKnIaOfWjYoHsw2eunWcg9pu2jlI1Q==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-1.5.1.tgz",
+      "integrity": "sha512-wZIafKCeLaQw5v0EmrgXG4okyMeX4EhyGp192AXjLmJttzxViq0JF2YFGxDM80PcoA30q1P2PW0VLtrJNp5btg==",
       "requires": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -1631,9 +1618,9 @@
       }
     },
     "@vaadin/vaadin-usage-statistics": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.0.10.tgz",
-      "integrity": "sha512-j8bD1Ecl/UB3a2lgzS3j8nh/X2jfA38Pg74vTSepyE6OgzFggjWIyWrlrnQScQik5PkjHByKW4Cj33Rpt2Zm8g==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.0.11.tgz",
+      "integrity": "sha512-6isKfOQnb6BSj181nehId4w8SOUKDLNcNza1RKdiNGgnOlqjZx/p4+FbJS9PQ4q0lwP1/TQa3Vx7SAWdoVfNOQ==",
       "requires": {
         "@vaadin/vaadin-development-mode-detector": "^2.0.0"
       }
@@ -2519,9 +2506,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000998",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000998.tgz",
-      "integrity": "sha512-8Tj5sPZR9kMHeDD9SZXIVr5m9ofufLLCG2Y4QwQrH18GIwG+kCc+zYdlR036ZRkuKjVVetyxeAgGA1xF7XdmzQ==",
+      "version": "1.0.30000999",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000999.tgz",
+      "integrity": "sha512-1CUyKyecPeksKwXZvYw0tEoaMCo/RwBlXmEtN5vVnabvO0KPd9RQLcaAuR9/1F+KDMv6esmOFWlsXuzDk+8rxg==",
       "dev": true
     },
     "chalk": {
@@ -3365,9 +3352,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.273",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.273.tgz",
-      "integrity": "sha512-0kUppiHQvHEENHh+nTtvTt4eXMwcPyWmMaj73GPrSEm3ldKhmmHuOH6IjrmuW6YmyS/fpXcLvMQLNVpqRhpNWw==",
+      "version": "1.3.277",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.277.tgz",
+      "integrity": "sha512-Czmsrgng89DOgJlIknnw9bn5431QdtnUwGp5YYiPwU1DbZQUxCLF+rc1ZC09VNAdalOPcvH6AE8BaA0H5HjI/w==",
       "dev": true
     },
     "elliptic": {
@@ -3407,13 +3394,13 @@
       }
     },
     "enhanced-resolve": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
-      "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
+      "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.4.0",
+        "memory-fs": "^0.5.0",
         "tapable": "^1.0.0"
       }
     },
@@ -5548,9 +5535,9 @@
       }
     },
     "memory-fs": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+      "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
       "dev": true,
       "requires": {
         "errno": "^0.1.3",
@@ -5851,20 +5838,12 @@
       }
     },
     "node-releases": {
-      "version": "1.1.33",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.33.tgz",
-      "integrity": "sha512-I0V30bWQEoHb+10W8oedVoUrdjW5wIkYm0w7vvcrPO95pZY738m1k77GF5sO0vKg5eXYg9oGtrMAETbgZGm11A==",
+      "version": "1.1.35",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.35.tgz",
+      "integrity": "sha512-JGcM/wndCN/2elJlU0IGdVEJQQnJwsLbgPCFd2pY7V0mxf17bZ0Gb/lgOtL29ZQhvEX5shnVhxQyZz3ex94N8w==",
       "dev": true,
       "requires": {
-        "semver": "^5.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "semver": "^6.3.0"
       }
     },
     "normalize-path": {
@@ -7415,9 +7394,9 @@
       "dev": true
     },
     "terser": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.4.tgz",
-      "integrity": "sha512-Kcrn3RiW8NtHBP0ssOAzwa2MsIRQ8lJWiBG/K7JgqPlomA3mtb2DEmp4/hrUA+Jujx+WZ02zqd7GYD+QRBB/2Q==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.8.tgz",
+      "integrity": "sha512-otmIRlRVmLChAWsnSFNO0Bfk6YySuBp6G9qrHiJwlLDd4mxe2ta4sjI7TzIR+W1nBMjilzrMcPOz9pSusgx3hQ==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -7996,6 +7975,18 @@
         "terser-webpack-plugin": "^1.1.0",
         "watchpack": "^1.5.0",
         "webpack-sources": "^1.3.0"
+      },
+      "dependencies": {
+        "memory-fs": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+          "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+          "dev": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
+        }
       }
     },
     "webpack-babel-multi-target-plugin": {
@@ -8050,6 +8041,16 @@
         "webpack-log": "^2.0.0"
       },
       "dependencies": {
+        "memory-fs": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+          "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+          "dev": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
+        },
         "mime": {
           "version": "2.4.4",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",

--- a/package.json
+++ b/package.json
@@ -22,5 +22,5 @@
     "html-webpack-plugin": "3.2.0",
     "script-ext-html-webpack-plugin": "2.1.4"
   },
-  "vaadinAppPackageHash": "c5f5409e8c46cf1a45e6596415747b92e8c980558b3b8e541841245ef19a0afd"
+  "vaadinAppPackageHash": "380708a1be7f71397e7b4edbfa70b1f7076fa20f5ce5b9bacd430d0c79116b88"
 }


### PR DESCRIPTION
Fixes #230

This removes the `frontend/src` subdirectory, and adds `frontend/views`.
The README files are updated to reflect that, and to have information
relevant with client-side TypeScript support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-spring/236)
<!-- Reviewable:end -->
