### PR TITLE
fix: avoid spring-boot:run timeout for clean builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,12 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <!-- Clean build and startup time for Vaadin apps sometimes may exceed
+                     the default Spring Boot's 30sec timeout.  -->
+                <configuration>
+                    <wait>500</wait>
+                    <maxAttempts>240</maxAttempts>
+                </configuration>
             </plugin>
 
             <!--


### PR DESCRIPTION
Clean build and startup time for Vaadin apps sometimes may exceed the default Spring Boot's 30sec timeout.
On the first startup Vaadin would run `npm install` and that may take more than 30 seconds depending on the network connection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-spring/238)
<!-- Reviewable:end -->
