### PR TITLE
fix: avoid spring-boot:run timeout for clean builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,12 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <!-- Clean build and startup time for Vaadin apps sometimes may exceed
+                     the default Spring Boot's 30sec timeout.  -->
+                <configuration>
+                    <wait>500</wait>
+                    <maxAttempts>240</maxAttempts>
+                </configuration>
             </plugin>
 
             <!--


### PR DESCRIPTION
Clean build and startup time for Vaadin apps sometimes may exceed the default Spring Boot's 30sec timeout.
On the first startup Vaadin would run `npm install` and that may take more than 30 seconds depending on the network connection.

(cherry picked from `master` PR #238 / commit d971cd6d229f99e00dd87a802265b1b0ed80c7dd)