### PR TITLE
add generated .ts files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # The following files are generated/updated by vaadin-maven-plugin
 node_modules/
+frontend/generated/
 
 # Browser drivers for local integration tests
 drivers/


### PR DESCRIPTION
When downloading and running a new V15 project from start.vaadin.com I do not want to see generated .ts files in the list of uncommitted files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-spring/274)
<!-- Reviewable:end -->
