### PR TITLE
Revert "Update to use AppShellConfigurator (#276)"

### DIFF
--- a/src/main/java/com/vaadin/starter/skeleton/spring/AppShell.java
+++ b/src/main/java/com/vaadin/starter/skeleton/spring/AppShell.java
@@ -1,8 +1,8 @@
 package com.vaadin.starter.skeleton.spring;
 
-import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.component.page.VaadinAppShell;
 import com.vaadin.flow.server.PWA;
 
 @PWA(name = "Project Base for Vaadin Flow with Spring", shortName = "Project Base")
-public class AppShell implements AppShellConfigurator {
+public class AppShell extends VaadinAppShell {
 }


### PR DESCRIPTION
This reverts commit 82fbd955af8b76779a799b17e4cfb0a47eba5e55, since the previous commit requires a new platform version.

Let's revert this change to keep the projects one gets from `start.vaadin.com` compile and run without issues. We need that until the next alpha of Vaadin 15 is released: the `AppShellConfigurator` interface needs Flow 3.0.0.alpha15+ that will be included into Vaadin 15.0.0.alpha12.

NOTE: using the latest released platform version (Vaadin 15.0.0.alpha11) and manually overriding the version of Flow to the latest (3.0.0.alpha15) does not work, because the latest Flow is not compatible with the platform versions of Vaadin components and with the Vaadin Flow add-on (https://github.com/vaadin/spring/issues/534).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-spring/278)
<!-- Reviewable:end -->
