### PR TITLE
Update .gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,3 +5,7 @@ tasks:
 ports:
   - port: 8080
     onOpen: open-preview
+github:
+  prebuilds:
+    # enable prebuilds for all branches in this repo
+    branches: true 


### PR DESCRIPTION
Set prebuilds on to all branches to allow v14 branch-based workspace to open faster from the vaadin.com/start page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-spring/292)
<!-- Reviewable:end -->
