### PR TITLE
Do not check for Mustache templates by default

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 server.port=8080
 logging.level.org.atmosphere = warn
+spring.mustache.check-template-location = false


### PR DESCRIPTION
Removes the "Cannot find template location: classpath:/templates/ (please add some templates, check your Mustache configuration, or set spring.mustache.check-template-location=false)" warning on startup

Fixes https://github.com/vaadin/flow/issues/8146

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-spring/343)
<!-- Reviewable:end -->
