### PR TITLE
Do not force VS Code to use an old JDK if found

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,6 @@
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 


### PR DESCRIPTION
When the project says it targets Java 8, VS Code will automatically use any JDK 8 version it can find, regardless of JAVA_HOME or the VS Code settings file it seems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-spring/387)
<!-- Reviewable:end -->
