### PR TITLE
Fixes gitpod commands to production mode for v17

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,5 @@
 tasks:
-  - init: mvn install spring-boot:start spring-boot:stop
-
+  - init: mvn install -Pproduction
     command: mvn
 ports:
   - port: 8080


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-spring/411)
<!-- Reviewable:end -->
