### PR TITLE
Remove obsolete properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,8 @@
     <artifactId>spring-skeleton</artifactId>
     <name>Project base for Spring Boot and Vaadin Flow</name>
     <version>1.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
         <vaadin.version>17.0.2</vaadin.version>
     </properties>
 


### PR DESCRIPTION
Removed properties are already defined by Spring Boot Parent.

If a different Java version is to be selected, use
<java.version> instead of <maven.compiler.source>.
Spring Boot Parent then sets related properties like <jvmTarget>, too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/skeleton-starter-flow-spring/413)
<!-- Reviewable:end -->
