### PR TITLE
Enable strict mode for the lit-plugin by default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "lit-plugin.strict": true
+}


### PR DESCRIPTION
Strict mode checks that there are imports for custom tags and more.