### PR TITLE
Use package for production for prebuild

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 tasks:
-  - init: mvn install spring-boot:start spring-boot:stop
+  - init: mvn package -Pproduction
 
     command: mvn
 ports:


### PR DESCRIPTION
A Spring Boot app is "started" before "npm install" or "webpack" has run, the production build finishes both before terminating