### PR TITLE
Use spring-boot-starter-validation instead of hibernate directly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,10 +108,9 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Bean validation implementation-->
         <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This should ensure that all parts needed for validation are included.

Fixes https://github.com/vaadin/spring/issues/673