### PR TITLE
Use spring-boot-starter-validation instead of hibernate directly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
This should ensure that all parts needed for validation are included.

Fixes https://github.com/vaadin/spring/issues/673