### PR TITLE
Revert "Upgrade to Spring Boot 2.4.6"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.6</version>
+        <version>2.4.5</version>
     </parent>
 
     <repositories>


### PR DESCRIPTION
Reverts vaadin/skeleton-starter-flow-spring#553

At least in some cases this causes the app not to start with
```
15:05:40.490 [restartedMain] ERROR org.springframework.boot.SpringApplication - Application run failed
java.lang.IllegalStateException: No subdirectories found for mandatory directory location 'file:./config/*/'.
	at org.springframework.util.Assert.state(Assert.java:76)
	at org.springframework.boot.context.config.StandardConfigDataLocationResolver.resolvePatternEmptyDirectories(StandardConfigDataLocationResolver.java:268)
	at org.springframework.boot.context.config.StandardConfigDataLocationResolver.resolveEmptyDirectories(StandardConfigDataLocationResolver.java:257)
```