### PR TITLE
test: Wait for elements to be present before asserts

### DIFF
--- a/src/test/java/org/vaadin/example/MainViewIT.java
+++ b/src/test/java/org/vaadin/example/MainViewIT.java
@@ -15,29 +15,31 @@ public class MainViewIT extends AbstractViewTest {
     @Test
     public void clickingButtonShowsNotification() {
         Assert.assertFalse($(NotificationElement.class).exists());
-        $(ButtonElement.class).first().click();
+        $(ButtonElement.class).waitForFirst().click();
         Assert.assertTrue($(NotificationElement.class).waitForFirst().isOpen());
     }
 
     @Test
     public void clickingButtonTwiceShowsTwoNotifications() {
         Assert.assertFalse($(NotificationElement.class).exists());
-        ButtonElement button = $(ButtonElement.class).first();
+        ButtonElement button = $(ButtonElement.class).waitForFirst();
         button.click();
         button.click();
+        $(NotificationElement.class).waitForFirst();
         Assert.assertEquals(2, $(NotificationElement.class).all().size());
     }
 
     @Test
     public void buttonIsUsingLumoTheme() {
-        WebElement element = $(ButtonElement.class).first();
+        WebElement element = $(ButtonElement.class).waitForFirst();
         assertThemePresentOnElement(element, Lumo.class);
     }
 
     @Test
     public void testClickButtonShowsHelloAnonymousUserNotificationWhenUserNameIsEmpty() {
-        ButtonElement button = $(ButtonElement.class).first();
+        ButtonElement button = $(ButtonElement.class).waitForFirst();
         button.click();
+        $(NotificationElement.class).waitForFirst();
         Assert.assertTrue($(NotificationElement.class).exists());
         NotificationElement notification = $(NotificationElement.class).first();
         Assert.assertEquals("Hello anonymous user", notification.getText());
@@ -45,10 +47,10 @@ public class MainViewIT extends AbstractViewTest {
 
     @Test
     public void testClickButtonShowsHelloUserNotificationWhenUserIsNotEmpty() {
-        TextFieldElement textField = $(TextFieldElement.class).first();
+        TextFieldElement textField = $(TextFieldElement.class).waitForFirst();
         textField.setValue("Vaadiner");
-        ButtonElement button = $(ButtonElement.class).first();
-        button.click();
+        $(ButtonElement.class).waitForFirst().click();
+        $(NotificationElement.class).waitForFirst();
         Assert.assertTrue($(NotificationElement.class).exists());
         NotificationElement notification = $(NotificationElement.class).first();
         Assert.assertEquals("Hello Vaadiner", notification.getText());
@@ -56,9 +58,10 @@ public class MainViewIT extends AbstractViewTest {
 
     @Test
     public void testEnterShowsHelloUserNotificationWhenUserIsNotEmpty() {
-        TextFieldElement textField = $(TextFieldElement.class).first();
+        TextFieldElement textField = $(TextFieldElement.class).waitForFirst();
         textField.setValue("Vaadiner");
         textField.sendKeys(Keys.ENTER);
+        $(NotificationElement.class).waitForFirst();
         Assert.assertTrue($(NotificationElement.class).exists());
         NotificationElement notification = $(NotificationElement.class).first();
         Assert.assertEquals("Hello Vaadiner", notification.getText());


### PR DESCRIPTION
## Description

Wait for elements to be present on the page before interacting with them. Otherwise, the tests fail randomly locally.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
