### PR TITLE
Remove vaadin.whitelisted-packages comment (V21)

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,3 @@ server.port=${PORT:8080}
 logging.level.org.atmosphere = warn
 spring.mustache.check-template-location = false
 
-# To improve the performance during development. 
-# For more information https://vaadin.com/docs/flow/spring/tutorial-spring-configuration.html#special-configuration-parameters
-# vaadin.whitelisted-packages= org/vaadin/example


### PR DESCRIPTION
Vaadin Start will add `vaadin.whitelisted-packages` by default to the downloaded starters. Since Vaadin Start depends on this skeleton to generate the starters, the comment about this property should be removed. 