### PR TITLE
Revert "Use safe log4j version"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
     <properties>
         <java.version>1.8</java.version>
         <vaadin.version>22.0.1</vaadin.version>
-        <log4j2.version>2.16.0</log4j2.version>
     </properties>
 
     <parent>


### PR DESCRIPTION
log4j2 is nowhere used by Vaadin. And adding the version entry to our starters might wrongly imply that we are endorsing the use of log4j2 (which we don't). Hence, this PR is removing the log4j2 version entry, leaving it for the discretion of the developer to use whichever logging framework they prefer.