### PR TITLE
Use latest webdrivermanager to avoid jsoup conflict

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>4.4.0</version>
+            <version>5.0.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Flow uses Jsoup 1.14
Webdrivermanager 4.4 uses Jsoup 1.13, 5.0 uses 1.14
