### PR TITLE
Add IntelliJ IDEA settings to prevent `npm install` prompt

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PackageJsonUpdateNotifier">
+    <dismissed value="$PROJECT_DIR$/package.json" />
+  </component>
+</project>


### PR DESCRIPTION
When opening a new project, IntelliJ IDEA detects `package.json` and provides a prompt to do `npm install`:
![image](https://user-images.githubusercontent.com/42799254/159915789-2e526da2-e674-4c00-ae5a-d45d0167aac7.png)



This is, however, redundant since `mvn` runs `npm install` in the process. Using this prompt can also lead to some build issues: https://github.com/vaadin/flow/issues/13247. 