### PR TITLE
Removed obsolete interface

### DIFF
--- a/src/main/java/org/vaadin/example/Application.java
+++ b/src/main/java/org/vaadin/example/Application.java
@@ -5,7 +5,6 @@ import com.vaadin.flow.server.PWA;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
 /**
  * The entry point of the Spring Boot application.
@@ -16,7 +15,7 @@ import org.springframework.boot.web.servlet.support.SpringBootServletInitializer
  */
 @SpringBootApplication
 @PWA(name = "Project Base for Vaadin with Spring", shortName = "Project Base")
-public class Application extends SpringBootServletInitializer implements AppShellConfigurator {
+public class Application implements AppShellConfigurator {
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);


### PR DESCRIPTION
I remove this from all apps each time I create one via this template. Only needed for war deployment, covered in Spring Boot docs, so I don't think we should have this here.