### PR TITLE
Patch Maven Wrapper to fix issue with paths with parentheses in Windows

### DIFF
--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -141,14 +141,15 @@ if exist %WRAPPER_JAR% (
         echo Downloading from: %DOWNLOAD_URL%
     )
 
-    FOR  %%I IN (%WRAPPER_JAR%) DO set WRAPPER_JAR_SHORT_NAME=%%~fsI
+    @setlocal EnableDelayedExpansion
     powershell -Command "&{"^
-    "$webclient = new-object System.Net.WebClient;"^
-    "if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
-    "$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
-    "}"^
-    "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR_SHORT_NAME%')"^
-    "}"
+          "$webclient = new-object System.Net.WebClient;"^
+          "if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
+          "$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
+          "}"^
+          "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%DOWNLOAD_URL%', '!WRAPPER_JAR!')"^
+          "}"
+    @endlocal
     if "%MVNW_VERBOSE%" == "true" (
         echo Finished downloading %WRAPPER_JAR%
     )

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -143,12 +143,12 @@ if exist %WRAPPER_JAR% (
 
     @setlocal EnableDelayedExpansion
     powershell -Command "&{"^
-          "$webclient = new-object System.Net.WebClient;"^
-          "if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
-          "$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
-          "}"^
-          "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%DOWNLOAD_URL%', '!WRAPPER_JAR!')"^
-          "}"
+		"$webclient = new-object System.Net.WebClient;"^
+		"if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
+		"$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
+		"}"^
+		"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%DOWNLOAD_URL%', '!WRAPPER_JAR!')"^
+		"}"
     @endlocal
     if "%MVNW_VERBOSE%" == "true" (
         echo Finished downloading %WRAPPER_JAR%

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -141,13 +141,14 @@ if exist %WRAPPER_JAR% (
         echo Downloading from: %DOWNLOAD_URL%
     )
 
+    FOR  %%I IN (%WRAPPER_JAR%) DO set WRAPPER_JAR_SHORT_NAME=%%~fsI
     powershell -Command "&{"^
-		"$webclient = new-object System.Net.WebClient;"^
-		"if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
-		"$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
-		"}"^
-		"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR%')"^
-		"}"
+    "$webclient = new-object System.Net.WebClient;"^
+    "if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
+    "$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
+    "}"^
+    "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR_SHORT_NAME%')"^
+    "}"
     if "%MVNW_VERBOSE%" == "true" (
         echo Finished downloading %WRAPPER_JAR%
     )


### PR DESCRIPTION
Running  `mvnw` fails in Windows if the project path includes parentheses. This is an issue with the Maven Wrapper: https://issues.apache.org/jira/browse/MWRAPPER-48. 

This PR includes a patch reported in the aforementioned ticket that fixes this problem. 