### PR TITLE
Enable auto-imports from package.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "lit-plugin.strict": true
+    "lit-plugin.strict": true,
+    "typescript.preferences.includePackageJsonAutoImports": "on"
 }


### PR DESCRIPTION
The VSCode default for auto-imports from package.json is `auto`, meaning that it could disable them.

It is critical for Hilla DX to have this enabled, so that all installed components are suggested, including ones not imported yet.