### PR TITLE
fix: Make Hilla projects work again

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,14 +167,11 @@
     "@polymer/polymer": "$@polymer/polymer",
     "proj4": "$proj4",
     "date-fns": "$date-fns",
-    "@vaadin/overlay": "$@vaadin/overlay",
-    "@vaadin-component-factory/vcf-nav": "$@vaadin-component-factory/vcf-nav",
-    "line-awesome": "$line-awesome"
+    "@vaadin/overlay": "$@vaadin/overlay"
   },
   "vaadin": {
     "dependencies": {
       "@polymer/polymer": "3.5.1",
-      "@vaadin-component-factory/vcf-nav": "1.0.6",
       "@vaadin/accordion": "24.0.0-beta1",
       "@vaadin/app-layout": "24.0.0-beta1",
       "@vaadin/avatar": "24.0.0-beta1",
@@ -245,7 +242,6 @@
       "@vaadin/virtual-list": "24.0.0-beta1",
       "construct-style-sheets-polyfill": "3.1.0",
       "date-fns": "2.29.3",
-      "line-awesome": "1.3.0",
       "lit": "2.6.1",
       "proj4": "2.8.1"
     },


### PR DESCRIPTION
line-awesome and vcf-nav should not be Vaadin managed dependencies
