### PR TITLE
chore: Simplify Spring Boot configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,11 +79,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <jvmArguments>-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005</jvmArguments>
-                    <wait>500</wait>
-                    <maxAttempts>240</maxAttempts>
-                </configuration>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
Waiting is not needed anymore as npm install runs in the background + the default is using a bundle.

The debug port is not really needed much
