### PR TITLE
Revert "Do not check for Mustache templates by default (#343)"

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 server.port=${PORT:8080}
 logging.level.org.atmosphere = warn
-spring.mustache.check-template-location = false
 
 # Launch the default browser when starting the application in development mode
 vaadin.launch-browser=true


### PR DESCRIPTION
This reverts commit 68cc295f89a37e4b1c34b44c45c1247891222608.

No longer needed since Mustache is no longer pulled in.