### PR TITLE
chore: Include spotless formatter

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+    "singleQuote": true,
+    "printWidth": 120,
+    "bracketSameLine": true
+  }
+  

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Vaadin web applications are full-stack and include both client-side and server-s
 | &nbsp;&nbsp;&nbsp;&nbsp;`Application.java` | Server entrypoint |
 | &nbsp;&nbsp;&nbsp;&nbsp;`AppShell.java`    | application-shell configuration |
 
+## Code Formatting
+
+The project includes the Spotless code formatter.
+
+To use it in IntelliJ, install the [https://plugins.jetbrains.com/plugin/22455-spotless-applier](IntelliJ plugin)
+To use it in VS Code, install the [https://marketplace.visualstudio.com/items?itemName=richardwillis.vscode-spotless-gradle ](VS Code extension)
+To use it from the command line, run `mvn spotless:apply`
+
 ## Useful links
 
 - Read the documentation at [vaadin.com/docs](https://vaadin.com/docs).

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,9 @@
                         <includes>
                             <include>src/main/frontend/**/*.ts</include>
                         </includes>
+                        <excludes>
+                            <exclude>src/main/frontend/generated/**</exclude>
+                        </excludes>
                         <prettier>
                             <prettierVersion>3.3.3</prettierVersion>
                             <configFile>.prettierrc.json</configFile>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,6 @@
                     <!-- Uncomment to format TypeScript files 
                         <typescript>
                         <includes>
-                            <include>frontend/**/*.ts</include>
                             <include>src/main/frontend/**/*.ts</include>
                         </includes>
                         <prettier>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
                 <configuration>
                     <java>
                         <palantirJavaFormat>
-                            <version>2.39.0</version>
+                            <version>2.50.0</version>
                         </palantirJavaFormat>
                     </java>
                     <!-- Uncomment to format TypeScript files 

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,30 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
-
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.43.0</version>
+                <configuration>
+                    <java>
+                        <palantirJavaFormat>
+                            <version>2.39.0</version>
+                        </palantirJavaFormat>
+                    </java>
+                    <!-- Uncomment to format TypeScript files 
+                        <typescript>
+                        <includes>
+                            <include>frontend/**/*.ts</include>
+                            <include>src/main/frontend/**/*.ts</include>
+                        </includes>
+                        <prettier>
+                            <prettierVersion>3.3.3</prettierVersion>
+                            <configFile>.prettierrc.json</configFile>
+                        </prettier>
+                    </typescript>
+                -->
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-maven-plugin</artifactId>

--- a/src/main/java/org/vaadin/example/Application.java
+++ b/src/main/java/org/vaadin/example/Application.java
@@ -3,7 +3,6 @@ package org.vaadin.example;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.theme.Theme;
-
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -22,5 +21,4 @@ public class Application implements AppShellConfigurator {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
     }
-
 }

--- a/src/main/java/org/vaadin/example/GreetService.java
+++ b/src/main/java/org/vaadin/example/GreetService.java
@@ -1,7 +1,6 @@
 package org.vaadin.example;
 
 import java.io.Serializable;
-
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,5 +13,4 @@ public class GreetService implements Serializable {
             return "Hello " + name;
         }
     }
-
 }

--- a/src/main/java/org/vaadin/example/MainView.java
+++ b/src/main/java/org/vaadin/example/MainView.java
@@ -1,15 +1,13 @@
 package org.vaadin.example;
 
-import org.springframework.beans.factory.annotation.Autowired;
-
 import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.html.Paragraph;
-import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Route;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * A sample Vaadin view class.
@@ -32,8 +30,7 @@ public class MainView extends VerticalLayout {
      * Build the initial UI state for the user accessing the application.
      *
      * @param service
-     *            The message service. Automatically injected Spring managed
-     *            bean.
+     *            The message service. Automatically injected Spring managed bean.
      */
     public MainView(@Autowired GreetService service) {
 
@@ -60,5 +57,4 @@ public class MainView extends VerticalLayout {
 
         add(textField, button);
     }
-
 }

--- a/src/test/java/org/vaadin/example/MainViewIT.java
+++ b/src/test/java/org/vaadin/example/MainViewIT.java
@@ -1,14 +1,13 @@
 package org.vaadin.example;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.openqa.selenium.Keys;
-
 import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.html.testbench.ParagraphElement;
 import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
 import com.vaadin.testbench.BrowserTest;
 import com.vaadin.testbench.BrowserTestBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.openqa.selenium.Keys;
 
 public class MainViewIT extends BrowserTestBase {
 
@@ -27,7 +26,7 @@ public class MainViewIT extends BrowserTestBase {
 
     @BeforeEach
     public void open() {
-        getDriver().get("http://"+getDeploymentHostname()+":8080/");
+        getDriver().get("http://" + getDeploymentHostname() + ":8080/");
     }
 
     @BrowserTest


### PR DESCRIPTION
Uses https://github.com/palantir/palantir-java-format for Java which seems to be pretty close to the 'Vaadin conventions' by default

Includes prettier for TypeScript but commented out to avoid requiring node from everybody

Fixes #1233