### PR TITLE
fix: fix aura stylesheet import

### DIFF
--- a/src/main/resources/META-INF/resources/styles.css
+++ b/src/main/resources/META-INF/resources/styles.css
@@ -1,4 +1,4 @@
-@import '/aura/aura.css';
+@import 'aura/aura.css';
 
 /* Example: CSS class name to center align the content . */
 .centered-content {


### PR DESCRIPTION
Importing Aura stylesheet with an absolute path breaks application styling when running on a context path different from ROOT. Since styles.css is relative to the application context, aura import can be relative as well.

