### PR TITLE
Removed obsolete configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,11 +137,6 @@
                 <version>${vaadin.version}</version>
                 <executions>
                     <execution>
-                        <goals>
-                            <goal>prepare-frontend</goal>
-                        </goals>
-                    </execution>
-                    <execution>
                         <id>package-for-production</id>
                         <goals>
                             <goal>build-frontend</goal>


### PR DESCRIPTION
The prepare-frontend goal is not needed with Spring Boot projects. 

It has never been on the configs e.g. via Spring Initializr