### PR TITLE
chore: Add GitHub Actions PR validation workflow

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,95 @@
+name: Starter Validation
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.head_ref }} || ${{ github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  JAVA_VERSION: '21'
+
+jobs:
+  validation:
+    name: Validate Starter
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Check secrets
+        run: |
+          [ -z "${{secrets.TB_LICENSE}}" ] \
+            && echo "🚫 **TB_LICENSE** is not defined, check that **${{github.repository}}** repo has a valid secret" \
+            | tee -a $GITHUB_STEP_SUMMARY && exit 1 || exit 0
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.9.0'
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'temurin'
+
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.8.7
+
+      - name: Cache Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Set TB License
+        run: |
+          TB_LICENSE=${{secrets.TB_LICENSE}}
+          mkdir -p ~/.vaadin/
+          echo '{"username":"'`echo $TB_LICENSE | cut -d / -f1`'","proKey":"'`echo $TB_LICENSE | cut -d / -f2`'"}' > ~/.vaadin/proKey
+
+      - name: Package
+        run: mvn -B -ntp clean package -DskipTests
+
+      - name: Verify in dev mode
+        run: |
+          mvn -B -ntp verify -Pit
+
+      - name: Verify in production mode
+        run: |
+          mvn -B -ntp verify -Pproduction,integration-tests,it
+
+      - name: Check for version mismatches
+        if: always()
+        run: |
+          if grep -r "has version mismatches with installed packages" target/ 2>/dev/null || \
+             grep -r "has version mismatches with installed packages" ./**/target/ 2>/dev/null; then
+            echo "::error::Bundle version mismatch detected, check build log"
+            exit 1
+          fi
+
+      - name: Package test reports
+        if: failure() || success()
+        run: |
+          find . -name surefire-reports -o -name failsafe-reports -o -name error-screenshots | \
+            tar -czf test-reports.tgz -T - 2>/dev/null || true
+
+      - name: Upload test reports
+        if: failure() || success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: test-reports.tgz
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -64,11 +64,11 @@ jobs:
 
       - name: Verify in dev mode
         run: |
-          mvn -B -ntp verify -Pit
+          mvn -B -ntp verify -Pit -Dcom.vaadin.testbench.Parameters.maxAttempts=2 -Dcom.vaadin.testbench.Parameters.headless=true
 
       - name: Verify in production mode
         run: |
-          mvn -B -ntp verify -Pproduction,integration-tests,it
+          mvn -B -ntp verify -Pproduction,integration-tests,it -Dcom.vaadin.testbench.Parameters.maxAttempts=2 -Dcom.vaadin.testbench.Parameters.headless=true
 
       - name: Check for version mismatches
         if: always()


### PR DESCRIPTION
Migrate PR validation from TeamCity to GitHub Actions aligned with Flow's validation patterns:
- Uses TB_LICENSE secret with same format as Flow
- Same setup: Java 21, Maven 3.8.7, Node 24.9.0
- TestBench license configuration via ~/.vaadin/proKey
- Maven build and test execution in dev and production modes
- Test report artifact collection
- Concurrency control and permission scoping
